### PR TITLE
Compilation error.  Must use await when instantiating getReleaseApi.

### DIFF
--- a/ServiceNow/Web/Tasks/ServiceNowTicketTask/updateTicket.ts
+++ b/ServiceNow/Web/Tasks/ServiceNowTicketTask/updateTicket.ts
@@ -20,7 +20,7 @@ export class UpdateTicket {
 
             this._vstsProvider = new VSTSProvider(this._configuration.tfsConfiguration);
             let connection = new vsts.WebApi(this._configuration.tfsConfiguration.rmUri, this.getAuthHandler());
-            let releaseApi = connection.getReleaseApi();
+            let releaseApi = await connection.getReleaseApi();
 
             let release = await releaseApi.getRelease(this._configuration.tfsConfiguration.teamProject, this._configuration.tfsConfiguration.releaseId);
             let recordNumbers = await this.getReleaseAttachments(release);

--- a/ServiceNow/Web/Tasks/ServiceNowTicketTask/validateState.ts
+++ b/ServiceNow/Web/Tasks/ServiceNowTicketTask/validateState.ts
@@ -20,7 +20,7 @@ export class ValidateState {
 
             this._vstsProvider = new VSTSProvider(this._configuration.tfsConfiguration);
             let connection = new vsts.WebApi(this._configuration.tfsConfiguration.rmUri, this.getAuthHandler());
-            let releaseApi = connection.getReleaseApi();
+            let releaseApi = await connection.getReleaseApi();
 
             let release = await releaseApi.getRelease(this._configuration.tfsConfiguration.teamProject, this._configuration.tfsConfiguration.releaseId);
             let recordNumbers = await this.getReleaseAttachments(release);


### PR DESCRIPTION
Running typescript compiler on the code in the Tasks folder throws an error when attempting to call getRelease.  Putting an await when calling connection.getReleaseApi() fixes the problem.